### PR TITLE
fix htpasswd auth when cookie-refresh is enabled

### DIFF
--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -85,11 +85,12 @@ func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 }
 
 func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error) {
-	if c == nil {
+	chunks := strings.Split(v, "|")
+
+	if c == nil || len(chunks) == 1 {
 		return decodeSessionStatePlain(v)
 	}
 
-	chunks := strings.Split(v, "|")
 	if len(chunks) != 4 {
 		err = fmt.Errorf("invalid number of fields (got %d expected 4)", len(chunks))
 		return


### PR DESCRIPTION
If cookie-refresh is enabled, a cookie cipher will be enabled
for encrypting the access token. But htpasswd-authenticated sessions
will never have a session token and will always use the "plain"
session state. We cannot assume that the "encrypted" form will
always be used if we have a cookie cipher.

(The "plain" form is still wrapped with authentication and expiry.)