### PR TITLE
tests: further deflake watcher tests for travis-ci

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,8 +34,8 @@
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  revision = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
-  version = "v1.2.11"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   branch = "master"
@@ -110,6 +110,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "62eef0e2fa9b2c385f7b2778e763486da6880d37"
+
+[[projects]]
+  branch = "master"
   name = "google.golang.org/api"
   packages = [
     "admin/directory/v1",
@@ -149,6 +155,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "abbe16e37b3dabfe8a3a522c92ab3f39e6ce1625cb568c772dd9bdb3ba25df0a"
+  inputs-digest = "2096167998c9334fc38262cf72cc6403e948cee059f2c89fa532dfa0b3a4c0e2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@
 
 [[constraint]]
   name = "github.com/fsnotify/fsnotify"
-  version = "~1.2.0"
+  version = "^1.2.0"
 
 [[constraint]]
   branch = "master"

--- a/watcher.go
+++ b/watcher.go
@@ -12,7 +12,7 @@ import (
 )
 
 func WaitForReplacement(filename string, watcher *fsnotify.Watcher) {
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		time.Sleep(100 * time.Millisecond)
 
 		if _, err := os.Stat(filename); err == nil {
@@ -25,39 +25,41 @@ func WaitForReplacement(filename string, watcher *fsnotify.Watcher) {
 	log.Printf("failed to resume watching for %s", filename)
 }
 
+func watchLoop(filename string, watcher *fsnotify.Watcher, done <-chan bool, action func()) {
+	for {
+		select {
+		case _ = <-done:
+			log.Printf("Shutting down watcher for: %s", filename)
+			watcher.Close()
+			return
+		case event := <-watcher.Events:
+			// On Arch Linux, it appears Chmod events precede Remove events,
+			// which causes a race between action() and the coming Remove event.
+			if event.Op == fsnotify.Chmod {
+				continue
+			}
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+				log.Printf("watching interrupted on event: %s", event)
+				watcher.Remove(filename)
+				WaitForReplacement(filename, watcher)
+			}
+			log.Printf("reloading after event: %s", event)
+			action()
+		case err := <-watcher.Errors:
+			log.Printf("error watching %s: %s", filename, err)
+		}
+	}
+}
+
 func WatchForUpdates(filename string, done <-chan bool, action func()) {
 	filename = filepath.Clean(filename)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal("failed to create watcher for ", filename, ": ", err)
 	}
-	go func() {
-		for {
-			select {
-			case _ = <-done:
-				log.Printf("Shutting down watcher for: %s", filename)
-				watcher.Close()
-				return
-			case event := <-watcher.Events:
-				// On Arch Linux, it appears Chmod events precede Remove events,
-				// which causes a race between action() and the coming Remove event.
-				if event.Op == fsnotify.Chmod {
-					continue
-				}
-				if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
-					log.Printf("watching interrupted on event: %s", event)
-					watcher.Remove(filename)
-					WaitForReplacement(filename, watcher)
-				}
-				log.Printf("reloading after event: %s", event)
-				action()
-			case err := <-watcher.Errors:
-				log.Printf("error watching %s: %s", filename, err)
-			}
-		}
-	}()
 	if err = watcher.Add(filename); err != nil {
 		log.Fatal("failed to add ", filename, " to watcher: ", err)
 	}
+	go watchLoop(filename, watcher, done, action)
 	log.Printf("watching %s for updates", filename)
 }


### PR DESCRIPTION
start by making backtraces a bit easier to read