### PR TITLE
Use entrypoint instead of cmd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 4180
 COPY --from=0  /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=0  /usr/local/bin/oauth2_proxy        /usr/local/bin/
 USER www-data
-CMD ["oauth2_proxy"]
+ENTRYPOINT ["oauth2_proxy"]


### PR DESCRIPTION
This allows users to override command line args like:
```
// docker-compose.yml

services:
  oauth2_proxy:
    image: ploxiln/oauth2_proxy
    command: >
      -config=/etc/oauth2_proxy.cfg
      ...
```