### PR TITLE
define command-line flags in new mainFlagSet() function

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,8 +13,7 @@ import (
 	"github.com/mreiferson/go-options"
 )
 
-func main() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+func mainFlagSet() *flag.FlagSet {
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	emailDomains := StringArray{}
@@ -23,9 +22,6 @@ func main() {
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
 	gitlabGroups := StringArray{}
-
-	config := flagSet.String("config", "", "path to config file")
-	showVersion := flagSet.Bool("version", false, "print version string")
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
@@ -84,6 +80,16 @@ func main() {
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
+
+	return flagSet
+}
+
+func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flagSet := mainFlagSet()
+
+	config := flagSet.String("config", "", "path to config file")
+	showVersion := flagSet.Bool("version", false, "print version string")
 
 	flagSet.Parse(os.Args[1:])
 

--- a/options_test.go
+++ b/options_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mreiferson/go-options"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,6 +71,23 @@ func TestGoogleGroupInvalidFile(t *testing.T) {
 func TestInitializedOptions(t *testing.T) {
 	o := testOptions()
 	assert.Equal(t, nil, o.Validate())
+}
+
+func TestMultiGitLabGroupOptions(t *testing.T) {
+	flagSet := mainFlagSet()
+	flagSet.Parse([]string{"--gitlab-group=one", "-gitlab-group=two"})
+	opts := NewOptions()
+	cfg := make(EnvOptions)
+	options.Resolve(opts, flagSet, cfg)
+
+	assert.Equal(t, []string{"one", "two"}, opts.GitLabGroups)
+
+	flagSet = mainFlagSet()
+	flagSet.Parse([]string{"--upstream=http://127.0.0.1:2000"})
+	opts = NewOptions()
+	options.Resolve(opts, flagSet, cfg)
+
+	assert.Equal(t, 0, len(opts.GitLabGroups))
 }
 
 // Note that it's not worth testing nonparseable URLs, since url.Parse()


### PR DESCRIPTION
for easier testing, and test multiple --gitlab-group flags
follow-up to #11