### PR TITLE
oidc provider: add oidc-policy option for oidc-issuer-url query param

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,6 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for log lines")
 
 	flagSet.String("provider", "google", "OAuth provider")
-	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
@@ -79,6 +78,8 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
+	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
+	flagSet.String("oidc-policy", "", "OpenID Connect policy name (for 'p' url query parameter")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 

--- a/options.go
+++ b/options.go
@@ -67,7 +67,6 @@ type Options struct {
 	// These options allow for other providers besides Google, with
 	// potential overrides.
 	Provider          string `flag:"provider" cfg:"provider"`
-	OIDCIssuerURL     string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
 	LoginURL          string `flag:"login-url" cfg:"login_url"`
 	RedeemURL         string `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL        string `flag:"profile-url" cfg:"profile_url"`
@@ -75,6 +74,8 @@ type Options struct {
 	ValidateURL       string `flag:"validate-url" cfg:"validate_url"`
 	Scope             string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
+	OIDCIssuerURL     string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
+	OIDCPolicy        string `flag:"oidc-policy" cfg:"oidc_policy"`
 
 	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
 	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format"`
@@ -263,7 +264,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		if o.OIDCIssuerURL == "" {
 			msgs = append(msgs, "missing-setting: oidc-issuer-url")
 		} else {
-			err := p.SetIssuerURL(o.OIDCIssuerURL)
+			err := p.SetIssuerURL(o.OIDCIssuerURL, o.OIDCPolicy)
 			if err != nil {
 				msgs = append(msgs, err.Error())
 			}


### PR DESCRIPTION
useful for Microsoft Azure AD B2C support
fixes #9

care to try this @marratj ? (though note that this fork does not have "huge cookie" support)