### PR TITLE
fix redirect-url option handling

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -151,7 +151,9 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	}
 
 	redirectURL := opts.redirectURL
-	redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
+	if redirectURL.String() == "" {
+		redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
+	}
 
 	log.Printf("OAuthProxy configured for %s Client ID: %s", opts.provider.Data().ProviderName, opts.ClientID)
 	refresh := "disabled"
@@ -186,7 +188,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 		SignOutPath:       fmt.Sprintf("%s/sign_out", opts.ProxyPrefix),
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),
-		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
+		OAuthCallbackPath: redirectURL.Path,
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 
 		ProxyPrefix:        opts.ProxyPrefix,


### PR DESCRIPTION
avoid user-supplied redirect URL getting clobbered

use redirectURL as OAuthCallbackURL (as it should be!)

based on https://github.com/pusher/oauth2_proxy/pull/10