### PR TITLE
GitHub provider: rename param limit to per_page

### DIFF
--- a/providers/github.go
+++ b/providers/github.go
@@ -67,8 +67,8 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 
 	for pn := 1; pn <= 10; pn++ {
 		params := url.Values{
-			"limit": {"100"},
-			"page":  {strconv.Itoa(pn)},
+			"per_page": {"100"},
+			"page":     {strconv.Itoa(pn)},
 		}
 		endpoint := &url.URL{
 			Scheme:   p.ValidateURL.Scheme,
@@ -130,7 +130,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 	}
 
 	params := url.Values{
-		"limit": {"100"},
+		"per_page": {"100"},
 	}
 	endpoint := &url.URL{
 		Scheme:   p.ValidateURL.Scheme,

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        []string{""},
 		"/user/emails": []string{""},
-		"/user/orgs":   []string{"limit=100&page=1", "limit=100&page=2", "limit=100&page=3"},
+		"/user/orgs":   []string{"page=1&per_page=100", "page=2&per_page=100", "page=3&per_page=100"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(
@@ -106,7 +106,7 @@ func TestGitHubProviderGetEmailAddress(t *testing.T) {
 
 	session := &SessionState{AccessToken: "imaginary_access_token"}
 	email, err := p.GetEmailAddress(session)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
 }
 
@@ -124,7 +124,7 @@ func TestGitHubProviderGetEmailAddressWithOrg(t *testing.T) {
 
 	session := &SessionState{AccessToken: "imaginary_access_token"}
 	email, err := p.GetEmailAddress(session)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
 }
 
@@ -142,7 +142,7 @@ func TestGitHubProviderGetEmailAddressFailedRequest(t *testing.T) {
 	// JSON to fail.
 	session := &SessionState{AccessToken: "unexpected_access_token"}
 	email, err := p.GetEmailAddress(session)
-	assert.NotEqual(t, nil, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, "", email)
 }
 
@@ -155,7 +155,7 @@ func TestGitHubProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 
 	session := &SessionState{AccessToken: "imaginary_access_token"}
 	email, err := p.GetEmailAddress(session)
-	assert.NotEqual(t, nil, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, "", email)
 }
 


### PR DESCRIPTION
the standard for the GitHub API now I guess
https://developer.github.com/v3/guides/traversing-with-pagination/

based on https://github.com/pusher/oauth2_proxy/pull/87