### PR TITLE
adjust redirect-url option handling more

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -188,7 +188,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 		SignOutPath:       fmt.Sprintf("%s/sign_out", opts.ProxyPrefix),
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),
-		OAuthCallbackPath: redirectURL.Path,
+		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 
 		ProxyPrefix:        opts.ProxyPrefix,


### PR DESCRIPTION
don't use the redirect-url option path part as the callback
handler path, use the normal oauth2_proxy prefix for that

follow-up to 1ed776bed2335c249e7529e55049783ca400f09f from #22
inspired by https://github.com/pusher/oauth2_proxy/issues/9#issuecomment-470375518