### PR TITLE
Set redirect URL path when host is present

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -171,7 +171,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	}
 
 	redirectURL := opts.redirectURL
-	if redirectURL.String() == "" {
+	if redirectURL.Path == "" {
 		redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
 	}
 


### PR DESCRIPTION
#22 introduced a regression when a pathless URL is provided as the redirect URL. In that case we want to set the path to the default oauth2 callback path.