### PR TITLE
GitHub provider: check email is both primary and verified

### DIFF
--- a/providers/github.go
+++ b/providers/github.go
@@ -206,8 +206,9 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 
 	var emails []struct {
-		Email   string `json:"email"`
-		Primary bool   `json:"primary"`
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
 	}
 
 	// if we require an Org or Team, check that first
@@ -252,7 +253,7 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 	}
 
 	for _, email := range emails {
-		if email.Primary {
+		if email.Primary && email.Verified {
 			return email.Email, nil
 		}
 	}

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -98,7 +98,7 @@ func TestGitHubProviderOverrides(t *testing.T) {
 }
 
 func TestGitHubProviderGetEmailAddress(t *testing.T) {
-	b := testGitHubBackend([]string{`[ {"email": "michael.bland@gsa.gov", "primary": true} ]`})
+	b := testGitHubBackend([]string{`[ {"email": "michael.bland@gsa.gov", "verified": true, "primary": true} ]`})
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)
@@ -110,10 +110,23 @@ func TestGitHubProviderGetEmailAddress(t *testing.T) {
 	assert.Equal(t, "michael.bland@gsa.gov", email)
 }
 
+func TestGitHubProviderGetEmailAddressNotVerified(t *testing.T) {
+	b := testGitHubBackend([]string{`[ {"email": "michael.bland@gsa.gov", "verified": false, "primary": true} ]`})
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testGitHubProvider(bURL.Host)
+
+	session := &SessionState{AccessToken: "imaginary_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.Equal(t, nil, err)
+	assert.Empty(t, "", email)
+}
+
 func TestGitHubProviderGetEmailAddressWithOrg(t *testing.T) {
 	b := testGitHubBackend([]string{
-		`[ {"email": "michael.bland@gsa.gov", "primary": true, "login":"testorg"} ]`,
-		`[ {"email": "michael.bland1@gsa.gov", "primary": true, "login":"testorg1"} ]`,
+		`[ {"email": "michael.bland@gsa.gov", "primary": true, "verified": true, "login":"testorg"} ]`,
+		`[ {"email": "michael.bland1@gsa.gov", "primary": true, "verified": true, "login":"testorg1"} ]`,
 		`[ ]`,
 	})
 	defer b.Close()


### PR DESCRIPTION
ported from https://github.com/pusher/oauth2_proxy/pull/96

not sure if one can have a non-verified primary email but this does seem safer