### PR TITLE
GitLab provider: honor explicit --scope option when using groups

### DIFF
--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -38,16 +38,18 @@ func NewGitLabProvider(p *ProviderData) *GitLabProvider {
 			Path:   "/api/v4/user",
 		}
 	}
-	if p.Scope == "" {
-		p.Scope = "read_user"
-	}
 	return &GitLabProvider{ProviderData: p}
 }
 
 func (p *GitLabProvider) SetGroups(groups []string) {
 	p.Groups = groups
-	if len(groups) > 0 {
-		p.Scope = "api"
+
+	if p.Scope == "" {
+		if len(groups) > 0 {
+			p.Scope = "api"
+		} else {
+			p.Scope = "read_user"
+		}
 	}
 }
 

--- a/providers/gitlab_test.go
+++ b/providers/gitlab_test.go
@@ -24,6 +24,7 @@ func testGitLabProvider(hostname string) *GitLabProvider {
 		updateURL(p.Data().ProfileURL, hostname)
 		updateURL(p.Data().ValidateURL, hostname)
 	}
+	p.SetGroups([]string{})
 	return p
 }
 


### PR DESCRIPTION
instead of always overriding scope to be "api" if when using groups

fixes #35 