### PR TITLE
more robust redirect url handling

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -469,7 +469,7 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 	if url.Path == p.SignInPath || url.Path == p.OAuthStartPath {
 		return false
 	}
-	if strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") {
+	if strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") && !strings.HasPrefix(redirect, "/\\") {
 		return true
 	}
 	if strings.HasPrefix(redirect, "http://") || strings.HasPrefix(redirect, "https://") {


### PR DESCRIPTION
accept rd param and X-Auth-Request-Redirect header from
both /sign_in and /start handlers

avoid accidental redirect to either /sign_in or /start handlers

inspired by https://github.com/pusher/oauth2_proxy/pull/150

------

Updated in February 2020 with the related:

check for /\ redirects

tricky open-redirect vulnerability, see
GHSA-qqxw-m5fj-f7gv

