### PR TITLE
add new option "xheaders" for whether trust X-Real-IP request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Usage of oauth2_proxy:
   -validate-url string: Access token validation endpoint
   -version: print version string
   -whitelist-domain value: allowed domain for redirection after authentication, leading '.' allows subdomains (may be given multiple times)
+  -xheaders: Trust X-Real-IP request header (appropriate when behind a reverse proxy) (default true)
 ```
 
 

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -9,6 +9,10 @@
 # tls_cert_file = ""
 # tls_key_file = ""
 
+## whether to trust the X-Real-IP request header for logging
+## disable if not running oauth2_proxy behind another reverse-proxy or load-balancer
+# xheaders = true
+
 ## the OAuth Redirect URL
 ## defaults to "https://" + requested host header + "/oauth2/callback"
 # redirect_url = "https://internalapp.yourcompany.com/oauth2/callback"

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -31,7 +31,7 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 			w.Write([]byte("test"))
 		}
 
-		h := LoggingHandler(buf, http.HandlerFunc(handler), true, test.Format)
+		h := LoggingHandler(buf, http.HandlerFunc(handler), true, true, test.Format)
 
 		r, _ := http.NewRequest("GET", "/foo/bar", nil)
 		r.RemoteAddr = "127.0.0.1"

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
-	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
+	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth header to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
@@ -70,6 +70,7 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
+	flagSet.Bool("xheaders", true, "Trust X-Real-IP request header (appropriate when behind a reverse proxy)")
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
 	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for request log lines")
 
@@ -142,7 +143,7 @@ func main() {
 	}
 
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat),
+		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.XHeaders, opts.RequestLoggingFormat),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/options.go
+++ b/options.go
@@ -81,6 +81,7 @@ type Options struct {
 	Scope             string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
 
+	XHeaders             bool   `flag:"xheaders" cfg:"xheaders"`
 	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
 	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format"`
 
@@ -118,6 +119,7 @@ func NewOptions() *Options {
 		PassAccessToken:      false,
 		PassHostHeader:       true,
 		ApprovalPrompt:       "force",
+		XHeaders:             true,
 		RequestLogging:       true,
 		RequestLoggingFormat: defaultRequestLoggingFormat,
 	}


### PR DESCRIPTION
this PR inspired by https://github.com/pusher/oauth2_proxy/pull/331
by Martin Campbell <martin@campbellsoftware.co.uk>

this option name inspired by the python Tornado framework HTTPServer