### PR TITLE
prevent open-redirect with tricky whitespace between slashes

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -483,7 +483,12 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 		log.Printf("invalid redirect: is auth start or sign_in path: %q", redirect)
 		return false
 	}
-	if strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") && !strings.HasPrefix(redirect, "/\\") {
+	if match, _ := regexp.MatchString(`^/(\s|\v)?(/|\\)`, redirect); match {
+		// matches `//` or `/\` or `/ /` or `/ \` (prevent open-redirect tricks)
+		log.Printf("invalid redirect: multi-slash prefix: %q", redirect)
+		return false
+	}
+	if strings.HasPrefix(redirect, "/") {
 		return true
 	}
 	if strings.HasPrefix(redirect, "http://") || strings.HasPrefix(redirect, "https://") {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -220,6 +220,39 @@ func TestIsValidRedirect(t *testing.T) {
 
 	invalidHttps2 := proxy.IsValidRedirect("https://evil.corp/redirect?rd=foo.bar")
 	assert.Equal(t, false, invalidHttps2)
+
+	openRedirect1 := proxy.IsValidRedirect("/\\evil.com")
+	assert.Equal(t, false, openRedirect1)
+
+	openRedirectSpace1 := proxy.IsValidRedirect("/ /evil.com")
+	assert.Equal(t, false, openRedirectSpace1)
+
+	openRedirectSpace2 := proxy.IsValidRedirect("/ \\evil.com")
+	assert.Equal(t, false, openRedirectSpace2)
+
+	openRedirectTab1 := proxy.IsValidRedirect("/\t/evil.com")
+	assert.Equal(t, false, openRedirectTab1)
+
+	openRedirectTab2 := proxy.IsValidRedirect("/\t\\evil.com")
+	assert.Equal(t, false, openRedirectTab2)
+
+	openRedirectVerticalTab1 := proxy.IsValidRedirect("/\v/evil.com")
+	assert.Equal(t, false, openRedirectVerticalTab1)
+
+	openRedirectVerticalTab2 := proxy.IsValidRedirect("/\v\\evil.com")
+	assert.Equal(t, false, openRedirectVerticalTab2)
+
+	openRedirectNewLine1 := proxy.IsValidRedirect("/\n/evil.com")
+	assert.Equal(t, false, openRedirectNewLine1)
+
+	openRedirectNewLine2 := proxy.IsValidRedirect("/\n\\evil.com")
+	assert.Equal(t, false, openRedirectNewLine2)
+
+	openRedirectCarriageReturn1 := proxy.IsValidRedirect("/\r/evil.com")
+	assert.Equal(t, false, openRedirectCarriageReturn1)
+
+	openRedirectCarriageReturn2 := proxy.IsValidRedirect("/\r\\evil.com")
+	assert.Equal(t, false, openRedirectCarriageReturn2)
 }
 
 type TestProvider struct {


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-j7px-6hwj-hpjg

Reported-by: Michele Romano <33063403+Mik317@users.noreply.github.com>
Co-authored-by: Harsh Jaiswal <rootxharsh@gmail.com>
Co-authored-by: @iamnoooob
Co-authored-by: Joel Speed <Joel.speed@hotmail.co.uk>