### PR TITLE
new option real-client-ip-header for alternatives to X-Real-IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Usage of oauth2_proxy:
   -provider string: OAuth provider (default "google")
   -proxy-prefix string: the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in) (default "/oauth2")
   -proxy-websockets: enables WebSocket proxying (default true)
+  -real-client-ip-header: HTTP header indicating the actual ip address of the client (blank to disable) (default "X-Real-IP")
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -request-logging: Log requests to stdout (default true)
@@ -326,7 +327,6 @@ Usage of oauth2_proxy:
   -validate-url string: Access token validation endpoint
   -version: print version string
   -whitelist-domain value: allowed domain for redirection after authentication, leading '.' allows subdomains (may be given multiple times)
-  -xheaders: Trust X-Real-IP request header (appropriate when behind a reverse proxy) (default true)
 ```
 
 

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -9,9 +9,9 @@
 # tls_cert_file = ""
 # tls_key_file = ""
 
-## whether to trust the X-Real-IP request header for logging
+## can be set to "X-Real-IP" (default), "X-Forwarded-For", "X-ProxyUser-IP", or "" (disabled)
 ## disable if not running oauth2_proxy behind another reverse-proxy or load-balancer
-# xheaders = true
+# real_client_ip_header = "X-Real-IP"
 
 ## the OAuth Redirect URL
 ## defaults to "https://" + requested host header + "/oauth2/callback"

--- a/http.go
+++ b/http.go
@@ -108,3 +108,17 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
 }
+
+// extract client ip address from configured header
+func extractClientIP(req *http.Request, header string) string {
+	if header != "" {
+		val := req.Header.Get(header)
+		if val != "" {
+			if header == "X-Forwarded-For" {
+				val = strings.TrimSpace(strings.SplitN(val, ",", 2)[0])
+			}
+			return val
+		}
+	}
+	return ""
+}

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -34,7 +34,7 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 			w.Write([]byte("test"))
 		}
 
-		h := LoggingHandler(buf, http.HandlerFunc(handler), true, true, test.Format)
+		h := LoggingHandler(buf, http.HandlerFunc(handler), true, "", test.Format)
 		r, _ := http.NewRequest("GET", "/foo/bar", nil)
 		r.RemoteAddr = "127.0.0.1"
 		r.Host = "test-server"

--- a/main.go
+++ b/main.go
@@ -71,9 +71,9 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
-	flagSet.Bool("xheaders", true, "Trust X-Real-IP request header (appropriate when behind a reverse proxy)")
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
 	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for request log lines")
+	flagSet.String("real-client-ip-header", "X-Real-IP", "HTTP header indicating the actual ip address of the client (blank to disable)")
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (e.g. https://accounts.google.com)")
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.XHeaders, opts.RequestLoggingFormat),
+		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RealClientIPHeader, opts.RequestLoggingFormat),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -70,7 +70,7 @@ type OAuthProxy struct {
 	PassUserHeaders     bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
-	XHeaders            bool
+	ClientIPHeader      string
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
 	skipAuthPreflight   bool
@@ -237,7 +237,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		BasicAuthPassword:  opts.BasicAuthPassword,
 		PassAccessToken:    opts.PassAccessToken,
 		SkipProviderButton: opts.SkipProviderButton,
-		XHeaders:           opts.XHeaders,
+		ClientIPHeader:     opts.RealClientIPHeader,
 		CookieCipher:       cipher,
 		templates:          loadTemplates(opts.CustomTemplatesDir),
 		Footer:             opts.Footer,
@@ -521,8 +521,10 @@ func (p *OAuthProxy) IsWhitelistedPath(path string) (ok bool) {
 
 func (p *OAuthProxy) getRemoteAddr(req *http.Request) (s string) {
 	s = req.RemoteAddr
-	if p.XHeaders && req.Header.Get("X-Real-IP") != "" {
-		s += fmt.Sprintf(" (%q)", req.Header.Get("X-Real-IP"))
+
+	hval := extractClientIP(req, p.ClientIPHeader)
+	if hval != "" {
+		s += fmt.Sprintf(" (%q)", hval)
 	}
 	return
 }


### PR DESCRIPTION
also remove the recently-added --xheaders option in favor
of disabling trust of the X-Real-IP header by setting the
real-client-ip-header option to a blank/empty string

inspired by https://github.com/oauth2-proxy/oauth2-proxy/pull/503