### PR TITLE
add --force-https option to redirect plain http requests to https

### DIFF
--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -34,7 +34,7 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 			w.Write([]byte("test"))
 		}
 
-		h := LoggingHandler(buf, http.HandlerFunc(handler), true, "", test.Format)
+		h := LoggingHandler(buf, http.HandlerFunc(handler), "", test.Format)
 		r, _ := http.NewRequest("GET", "/foo/bar", nil)
 		r.RemoteAddr = "127.0.0.1"
 		r.Host = "test-server"

--- a/options.go
+++ b/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets"`
 	HttpAddress     string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress    string `flag:"https-address" cfg:"https_address"`
+	ForceHTTPS      bool   `flag:"force-https" cfg:"force_https"`
 	RedirectURL     string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID        string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret    string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
@@ -108,6 +109,7 @@ func NewOptions() *Options {
 		ProxyWebSockets:      true,
 		HttpAddress:          "127.0.0.1:4180",
 		HttpsAddress:         ":443",
+		ForceHTTPS:           false,
 		DisplayHtpasswdForm:  true,
 		CookieName:           "_oauth2_proxy",
 		CookieSecure:         true,


### PR DESCRIPTION
inspired by https://github.com/oauth2-proxy/oauth2-proxy/pull/285

Also refactor loggingHandler to have a separate "disabled" variant
noLoggingHandler, which is used when request-logging is disabled
(instead of checking enabled on every request).