### PR TITLE
rename a few config options for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The Azure AD auth provider uses `openid` as it default scope. It uses `https://g
 The GitHub auth provider supports two additional parameters to restrict authentication to Organization or Team level access. Restricting by org and team is normally accompanied with `--email-domain=*`
 
     -github-org="": restrict logins to members of this organisation
-    -github-team="": restrict logins to members of any of these teams (slug), separated by a comma
+    -github-team="": restrict logins to members of this team (slug) (or teams, if this flag is given multiple times)
 
 If you are using GitHub enterprise, make sure you set the following to the appropriate url:
 
@@ -321,8 +321,8 @@ Usage of oauth2_proxy:
   -skip-oidc-discovery: Skip OIDC discovery (login-url, redeem-url and oidc-jwks-url must be configured)
   -skip-provider-button: will skip sign-in-page to directly reach the next step: oauth/start
   -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS
-  -tls-cert string: path to certificate file
-  -tls-key string: path to private key file
+  -tls-cert-file string: path to certificate file
+  -tls-key-file string: path to private key file
   -upstream value: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
   -validate-url string: Access token validation endpoint
   -version: print version string

--- a/main.go
+++ b/main.go
@@ -23,12 +23,13 @@ func mainFlagSet() *flag.FlagSet {
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
 	gitlabGroups := StringArray{}
+	githubTeams := StringArray{}
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.Bool("force-https", false, "redirect http requests to https")
-	flagSet.String("tls-cert", "", "path to certificate file")
-	flagSet.String("tls-key", "", "path to private key file")
+	flagSet.String("tls-cert-file", "", "path to certificate file")
+	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
@@ -48,7 +49,7 @@ func mainFlagSet() *flag.FlagSet {
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
-	flagSet.String("github-team", "", "restrict logins to members of this team (slug) (may be given multiple times)")
+	flagSet.Var(&githubTeams, "github-team", "restrict logins to members of this team (slug) (may be given multiple times)")
 	flagSet.Var(&gitlabGroups, "gitlab-group", "restrict logins to members of this group (full path) (may be given multiple times)")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times)")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPrefix     string `flag:"proxy-prefix" cfg:"proxy-prefix"`
+	ProxyPrefix     string `flag:"proxy-prefix" cfg:"proxy_prefix"`
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets"`
 	HttpAddress     string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress    string `flag:"https-address" cfg:"https_address"`
@@ -26,8 +26,8 @@ type Options struct {
 	RedirectURL     string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID        string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret    string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-	TLSCertFile     string `flag:"tls-cert" cfg:"tls_cert_file"`
-	TLSKeyFile      string `flag:"tls-key" cfg:"tls_key_file"`
+	TLSCertFile     string `flag:"tls-cert-file" cfg:"tls_cert_file"`
+	TLSKeyFile      string `flag:"tls-key-file" cfg:"tls_key_file"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
@@ -35,9 +35,9 @@ type Options struct {
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
 	WhitelistDomains         []string `flag:"whitelist-domain" cfg:"whitelist_domains" env:"OAUTH2_PROXY_WHITELIST_DOMAINS"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
-	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+	GitHubTeams              []string `flag:"github-team" cfg:"github_teams"`
 	GitLabGroups             []string `flag:"gitlab-group" cfg:"gitlab_groups"`
-	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
+	GoogleGroups             []string `flag:"google-group" cfg:"google_groups"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
 	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
@@ -272,7 +272,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	case *providers.BitbucketProvider:
 		p.SetTeam(o.BitbucketTeam)
 	case *providers.GitHubProvider:
-		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
+		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeams)
 	case *providers.GitLabProvider:
 		p.SetGroups(o.GitLabGroups)
 	case *providers.GoogleProvider:


### PR DESCRIPTION
config:
  * proxy-prefix -> proxy_prefix
  * google_group -> google_groups
  * github_team -> github_teams

flags:
  * tls-cert -> tls-cert-file
  * tls-key -> tls-key-file

flags always use dashes, config options always use underscores

flags are singular if they can be specified multiple times,
config options are plural if they take a list

inspired by https://github.com/oauth2-proxy/oauth2-proxy/pull/186

Co-authored-by: Joel Speed <Joel.speed@hotmail.co.uk>