### PR TITLE
do not set cache-control header for auth-only endpoint

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -660,7 +660,9 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (p *OAuthProxy) AuthenticateOnly(rw http.ResponseWriter, req *http.Request) {
-	preventCaching(rw)
+	// allow caching, do not send no-cache header
+	// typically not accessed directly by browsers
+	// short caching sometimes useful to prevent multiple simultaneous refreshes
 	status := p.Authenticate(rw, req)
 	if status == http.StatusAccepted {
 		rw.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
typically not accessed directly by browsers,
short caching sometimes useful to prevent multiple simultaneous refreshes

inspired by https://github.com/oauth2-proxy/oauth2-proxy/pull/662